### PR TITLE
Update sample to use string resources for changing the app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,25 @@ kotlin {
 
 ### Android
 
-### Changing the App name
+### Changing the App name using XML (supports localizing)
+
+Create a `strings.xml` file for each flavor. E.g.:
+
+1. `config/development/androidMain/values/res/strings.xml`
+2. `config/production/androidMain/values/res/strings.xml`
+
+Add a string with the name `app_name` like you normally would.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">KMP Flavor Dev</string>
+</resources>
+```
+
+This string can now be used in AndroidManifest.xml like you normally would
+
+### Changing the App name using Gradle
 ```kotlin
 android {
     namespace = "com.rakangsoftware.flavors"

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -63,10 +63,6 @@ android {
     sourceSets["main"].resources.srcDirs("src/commonMain/resources")
 
     defaultConfig {
-        when (flavor) {
-            "development" -> resValue("string", "app_name", "KMP Flavor Dev")
-            else -> resValue("string", "app_name", "KMP Flavor")
-        }
         applicationId = "com.rakangsoftware.flavors"
         applicationIdSuffix = suffix
         minSdk = libs.versions.android.minSdk.get().toInt()

--- a/config/development/src/androidMain/res/values/strings.xml
+++ b/config/development/src/androidMain/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">KMP Flavor Dev</string>
+</resources>

--- a/config/production/src/androidMain/res/values/strings.xml
+++ b/config/production/src/androidMain/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">KMP Flavor Prod</string>
+</resources>


### PR DESCRIPTION
Updated the sample to use plain old string resources for the app name to minimize the complexity of the gradle file and keep as much of the config as possible in the respective module. Also supports localization, which is nice.

Left the gradle sample in the readme, for people who are curious about that.